### PR TITLE
Re-enabled sorting by owner using 'displayName' field

### DIFF
--- a/src/api/rest.tsx
+++ b/src/api/rest.tsx
@@ -44,7 +44,7 @@ export const getBusinessServices = (
         field = "name";
         break;
       case BusinessServiceSortBy.OWNER:
-        field = "owner";
+        field = "owner.displayName";
         break;
       default:
         throw new Error("Could not define SortBy field name");

--- a/src/pages/controls/business-services/business-services.tsx
+++ b/src/pages/controls/business-services/business-services.tsx
@@ -156,9 +156,7 @@ export const BusinessServices: React.FC = () => {
     { title: t("terms.description"), transforms: [cellWidth(40)] },
     {
       title: t("terms.owner"),
-      transforms: [
-        // sortable
-      ],
+      transforms: [sortable],
     },
     {
       title: "",


### PR DESCRIPTION
Re-enabled sorting by owner changing it to use, just like it happens for filtering, the 'displayName' field