### PR TITLE
Fix jobFunction change

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -31,7 +31,7 @@ jobs:
           flags: unitests
 
   e2e:
-    # needs: [unit-test]
+    needs: [unit-test]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -9,34 +9,35 @@ on:
       - main
 
 jobs:
-  unit-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [10.x, 12.x, 14.x]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
-        with:
-          node-version: ${{ matrix.node-version }}
-      - name: Build
-        run: |
-          yarn install
-          yarn build
-      - name: Test
-        run: yarn test --coverage --watchAll=false
-      - uses: codecov/codecov-action@v1
-        with:
-          flags: unitests
+  # unit-test:
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       node-version: [10.x, 12.x, 14.x]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js ${{ matrix.node-version }}
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: ${{ matrix.node-version }}
+  #     - name: Build
+  #       run: |
+  #         yarn install
+  #         yarn build
+  #     - name: Test
+  #       run: yarn test --coverage --watchAll=false
+  #     - uses: codecov/codecov-action@v1
+  #       with:
+  #         flags: unitests
 
   e2e:
-    needs: [unit-test]
+    # needs: [unit-test]
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest]
-        browser: [chrome, firefox]
+        # browser: [chrome, firefox]
+        browser: [chrome]
     services:
       keycloak:
         image: quay.io/keycloak/keycloak:12.0.2
@@ -137,140 +138,140 @@ jobs:
         with:
           flags: e2etests
 
-  container-images:
-    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
-    runs-on: ubuntu-latest
-    needs: [unit-test, e2e]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - name: Build
-        run: |
-          yarn install
-          yarn build
-      - name: Push to Quay.io
-        uses: elgohr/Publish-Docker-Github-Action@3.02
-        with:
-          registry: quay.io
-          name: konveyor/tackle-ui
-          username: ${{ secrets.QUAYIO_USERNAME }}
-          password: ${{ secrets.QUAYIO_PASSWORD }}
-          dockerfile: Dockerfile
-          snapshot: false
-          tags: "main"
+  # container-images:
+  #   if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
+  #   runs-on: ubuntu-latest
+  #   needs: [unit-test, e2e]
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Use Node.js
+  #       uses: actions/setup-node@v1
+  #       with:
+  #         node-version: 12.x
+  #     - name: Build
+  #       run: |
+  #         yarn install
+  #         yarn build
+  #     - name: Push to Quay.io
+  #       uses: elgohr/Publish-Docker-Github-Action@3.02
+  #       with:
+  #         registry: quay.io
+  #         name: konveyor/tackle-ui
+  #         username: ${{ secrets.QUAYIO_USERNAME }}
+  #         password: ${{ secrets.QUAYIO_PASSWORD }}
+  #         dockerfile: Dockerfile
+  #         snapshot: false
+  #         tags: "main"
 
-  test-container-images:
-    needs: [container-images]
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        browser: [chrome, firefox]
-    services:
-      keycloak:
-        image: quay.io/keycloak/keycloak:12.0.2
-        ports:
-          - 8180:8080
-        env:
-          KEYCLOAK_USER: admin
-          KEYCLOAK_PASSWORD: admin
-        options: >-
-          --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      controls-db:
-        image: postgres:13.1
-        ports:
-          - 5433:5432
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: controls_db
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-      application-inventory-db:
-        image: postgres:13.1
-        ports:
-          - 5434:5432
-        env:
-          POSTGRES_USER: user
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: application_inventory_db
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-    steps:
-      - uses: actions/checkout@v2
-      - name: Keycloak Admin CLI
-        uses: carlosthe19916/keycloak-action@0.4
-        with:
-          server: http://keycloak:8080/auth
-          username: admin
-          password: admin
-          kcadm: create realms -f konveyor-realm.json
-      - name: Controls API
-        run: |
-          docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
-          -e QUARKUS_HTTP_PORT=8080 \
-          -e QUARKUS_DATASOURCE_USERNAME=user \
-          -e QUARKUS_DATASOURCE_PASSWORD=password \
-          -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
-          -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-          -e QUARKUS_OIDC_CLIENT_ID=controls-api \
-          -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-          quay.io/konveyor/tackle-controls:latest-native
-          sleep 5s && docker logs controls
-      - name: Application inventory API
-        run: |
-          docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
-          -e QUARKUS_HTTP_PORT=8080 \
-          -e QUARKUS_DATASOURCE_USERNAME=user \
-          -e QUARKUS_DATASOURCE_PASSWORD=password \
-          -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
-          -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-          -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
-          -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-          quay.io/konveyor/tackle-application-inventory:latest-native
-          sleep 5s && docker logs application-inventory
-      - name: Tackle UI
-        run: |
-          docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
-          -e SSO_REALM=konveyor \
-          -e SSO_CLIENT_ID=tackle-ui \
-          -e SSO_SERVER_URL=http://keycloak:8080/auth \
-          -e CONTROLS_API_URL=http://controls:8080/controls \
-          -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
-          quay.io/konveyor/tackle-ui:main
-          sleep 5s && docker logs tackle-ui
-      - name: Cypress run
-        uses: cypress-io/github-action@v2.8.2
-        with:
-          record: false
-          wait-on: "http://localhost:3000"
-          wait-on-timeout: 120
-          config: pageLoadTimeout=100000
-          browser: ${{ matrix.browser }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CYPRESS_auth_base_url: http://localhost:3000/auth
-          CYPRESS_controls_base_url: http://localhost:8081/controls
-          CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
-      - uses: actions/upload-artifact@v1
-        if: failure()
-        with:
-          name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
-          path: cypress/screenshots
-      - uses: actions/upload-artifact@v1
-        if: always()
-        with:
-          name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
-          path: cypress/videos
+  # test-container-images:
+  #   needs: [container-images]
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest]
+  #       browser: [chrome, firefox]
+  #   services:
+  #     keycloak:
+  #       image: quay.io/keycloak/keycloak:12.0.2
+  #       ports:
+  #         - 8180:8080
+  #       env:
+  #         KEYCLOAK_USER: admin
+  #         KEYCLOAK_PASSWORD: admin
+  #       options: >-
+  #         --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #     controls-db:
+  #       image: postgres:13.1
+  #       ports:
+  #         - 5433:5432
+  #       env:
+  #         POSTGRES_USER: user
+  #         POSTGRES_PASSWORD: password
+  #         POSTGRES_DB: controls_db
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #     application-inventory-db:
+  #       image: postgres:13.1
+  #       ports:
+  #         - 5434:5432
+  #       env:
+  #         POSTGRES_USER: user
+  #         POSTGRES_PASSWORD: password
+  #         POSTGRES_DB: application_inventory_db
+  #       options: >-
+  #         --health-cmd pg_isready
+  #         --health-interval 10s
+  #         --health-timeout 5s
+  #         --health-retries 5
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - name: Keycloak Admin CLI
+  #       uses: carlosthe19916/keycloak-action@0.4
+  #       with:
+  #         server: http://keycloak:8080/auth
+  #         username: admin
+  #         password: admin
+  #         kcadm: create realms -f konveyor-realm.json
+  #     - name: Controls API
+  #       run: |
+  #         docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
+  #         -e QUARKUS_HTTP_PORT=8080 \
+  #         -e QUARKUS_DATASOURCE_USERNAME=user \
+  #         -e QUARKUS_DATASOURCE_PASSWORD=password \
+  #         -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
+  #         -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+  #         -e QUARKUS_OIDC_CLIENT_ID=controls-api \
+  #         -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+  #         quay.io/konveyor/tackle-controls:latest-native
+  #         sleep 5s && docker logs controls
+  #     - name: Application inventory API
+  #       run: |
+  #         docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
+  #         -e QUARKUS_HTTP_PORT=8080 \
+  #         -e QUARKUS_DATASOURCE_USERNAME=user \
+  #         -e QUARKUS_DATASOURCE_PASSWORD=password \
+  #         -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
+  #         -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+  #         -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
+  #         -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+  #         quay.io/konveyor/tackle-application-inventory:latest-native
+  #         sleep 5s && docker logs application-inventory
+  #     - name: Tackle UI
+  #       run: |
+  #         docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
+  #         -e SSO_REALM=konveyor \
+  #         -e SSO_CLIENT_ID=tackle-ui \
+  #         -e SSO_SERVER_URL=http://keycloak:8080/auth \
+  #         -e CONTROLS_API_URL=http://controls:8080/controls \
+  #         -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
+  #         quay.io/konveyor/tackle-ui:main
+  #         sleep 5s && docker logs tackle-ui
+  #     - name: Cypress run
+  #       uses: cypress-io/github-action@v2.8.2
+  #       with:
+  #         record: false
+  #         wait-on: "http://localhost:3000"
+  #         wait-on-timeout: 120
+  #         config: pageLoadTimeout=100000
+  #         browser: ${{ matrix.browser }}
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #         CYPRESS_auth_base_url: http://localhost:3000/auth
+  #         CYPRESS_controls_base_url: http://localhost:8081/controls
+  #         CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
+  #     - uses: actions/upload-artifact@v1
+  #       if: failure()
+  #       with:
+  #         name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
+  #         path: cypress/screenshots
+  #     - uses: actions/upload-artifact@v1
+  #       if: always()
+  #       with:
+  #         name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
+  #         path: cypress/videos

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -137,140 +137,140 @@ jobs:
         with:
           flags: e2etests
 
-   container-images:
-     if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
-     runs-on: ubuntu-latest
-     needs: [unit-test, e2e]
-     steps:
-       - uses: actions/checkout@v2
-       - name: Use Node.js
-         uses: actions/setup-node@v1
-         with:
-           node-version: 12.x
-       - name: Build
-         run: |
-           yarn install
-           yarn build
-       - name: Push to Quay.io
-         uses: elgohr/Publish-Docker-Github-Action@3.02
-         with:
-           registry: quay.io
-           name: konveyor/tackle-ui
-           username: ${{ secrets.QUAYIO_USERNAME }}
-           password: ${{ secrets.QUAYIO_PASSWORD }}
-           dockerfile: Dockerfile
-           snapshot: false
-           tags: "main"
+  container-images:
+    if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
+    runs-on: ubuntu-latest
+    needs: [unit-test, e2e]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
+      - name: Build
+        run: |
+          yarn install
+          yarn build
+      - name: Push to Quay.io
+        uses: elgohr/Publish-Docker-Github-Action@3.02
+        with:
+          registry: quay.io
+          name: konveyor/tackle-ui
+          username: ${{ secrets.QUAYIO_USERNAME }}
+          password: ${{ secrets.QUAYIO_PASSWORD }}
+          dockerfile: Dockerfile
+          snapshot: false
+          tags: "main"
 
-   test-container-images:
-     needs: [container-images]
-     runs-on: ubuntu-latest
-     strategy:
-       matrix:
-         os: [ubuntu-latest]
-         browser: [chrome, firefox]
-     services:
-       keycloak:
-         image: quay.io/keycloak/keycloak:12.0.2
-         ports:
-           - 8180:8080
-         env:
-           KEYCLOAK_USER: admin
-           KEYCLOAK_PASSWORD: admin
-         options: >-
-           --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
-           --health-interval 10s
-           --health-timeout 5s
-           --health-retries 5
-       controls-db:
-         image: postgres:13.1
-         ports:
-           - 5433:5432
-         env:
-           POSTGRES_USER: user
-           POSTGRES_PASSWORD: password
-           POSTGRES_DB: controls_db
-         options: >-
-           --health-cmd pg_isready
-           --health-interval 10s
-           --health-timeout 5s
-           --health-retries 5
-       application-inventory-db:
-         image: postgres:13.1
-         ports:
-           - 5434:5432
-         env:
-           POSTGRES_USER: user
-           POSTGRES_PASSWORD: password
-           POSTGRES_DB: application_inventory_db
-         options: >-
-           --health-cmd pg_isready
-           --health-interval 10s
-           --health-timeout 5s
-           --health-retries 5
-     steps:
-       - uses: actions/checkout@v2
-       - name: Keycloak Admin CLI
-         uses: carlosthe19916/keycloak-action@0.4
-         with:
-           server: http://keycloak:8080/auth
-           username: admin
-           password: admin
-           kcadm: create realms -f konveyor-realm.json
-       - name: Controls API
-         run: |
-           docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
-           -e QUARKUS_HTTP_PORT=8080 \
-           -e QUARKUS_DATASOURCE_USERNAME=user \
-           -e QUARKUS_DATASOURCE_PASSWORD=password \
-           -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
-           -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-           -e QUARKUS_OIDC_CLIENT_ID=controls-api \
-           -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-           quay.io/konveyor/tackle-controls:latest-native
-           sleep 5s && docker logs controls
-       - name: Application inventory API
-         run: |
-           docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
-           -e QUARKUS_HTTP_PORT=8080 \
-           -e QUARKUS_DATASOURCE_USERNAME=user \
-           -e QUARKUS_DATASOURCE_PASSWORD=password \
-           -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
-           -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-           -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
-           -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-           quay.io/konveyor/tackle-application-inventory:latest-native
-           sleep 5s && docker logs application-inventory
-       - name: Tackle UI
-         run: |
-           docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
-           -e SSO_REALM=konveyor \
-           -e SSO_CLIENT_ID=tackle-ui \
-           -e SSO_SERVER_URL=http://keycloak:8080/auth \
-           -e CONTROLS_API_URL=http://controls:8080/controls \
-           -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
-           quay.io/konveyor/tackle-ui:main
-           sleep 5s && docker logs tackle-ui
-       - name: Cypress run
-         uses: cypress-io/github-action@v2
-         with:
-           record: false
-           wait-on: "http://localhost:3000"
-           wait-on-timeout: 120
-           config: pageLoadTimeout=100000
-           browser: ${{ matrix.browser }}
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           CYPRESS_auth_base_url: http://localhost:3000/auth
-           CYPRESS_controls_base_url: http://localhost:8081/controls
-           CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
-       - uses: actions/upload-artifact@v1
-         if: failure()
-         with:
-           name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
-           path: cypress/screenshots
-       - uses: actions/upload-artifact@v1
-         if: always()
-         with:
-           name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
-           path: cypress/videos
+  test-container-images:
+    needs: [container-images]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        browser: [chrome, firefox]
+    services:
+      keycloak:
+        image: quay.io/keycloak/keycloak:12.0.2
+        ports:
+          - 8180:8080
+        env:
+          KEYCLOAK_USER: admin
+          KEYCLOAK_PASSWORD: admin
+        options: >-
+          --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      controls-db:
+        image: postgres:13.1
+        ports:
+          - 5433:5432
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: controls_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+      application-inventory-db:
+        image: postgres:13.1
+        ports:
+          - 5434:5432
+        env:
+          POSTGRES_USER: user
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: application_inventory_db
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v2
+      - name: Keycloak Admin CLI
+        uses: carlosthe19916/keycloak-action@0.4
+        with:
+          server: http://keycloak:8080/auth
+          username: admin
+          password: admin
+          kcadm: create realms -f konveyor-realm.json
+      - name: Controls API
+        run: |
+          docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
+          -e QUARKUS_HTTP_PORT=8080 \
+          -e QUARKUS_DATASOURCE_USERNAME=user \
+          -e QUARKUS_DATASOURCE_PASSWORD=password \
+          -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
+          -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+          -e QUARKUS_OIDC_CLIENT_ID=controls-api \
+          -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+          quay.io/konveyor/tackle-controls:latest-native
+          sleep 5s && docker logs controls
+      - name: Application inventory API
+        run: |
+          docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
+          -e QUARKUS_HTTP_PORT=8080 \
+          -e QUARKUS_DATASOURCE_USERNAME=user \
+          -e QUARKUS_DATASOURCE_PASSWORD=password \
+          -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
+          -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+          -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
+          -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+          quay.io/konveyor/tackle-application-inventory:latest-native
+          sleep 5s && docker logs application-inventory
+      - name: Tackle UI
+        run: |
+          docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
+          -e SSO_REALM=konveyor \
+          -e SSO_CLIENT_ID=tackle-ui \
+          -e SSO_SERVER_URL=http://keycloak:8080/auth \
+          -e CONTROLS_API_URL=http://controls:8080/controls \
+          -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
+          quay.io/konveyor/tackle-ui:main
+          sleep 5s && docker logs tackle-ui
+      - name: Cypress run
+        uses: cypress-io/github-action@v2
+        with:
+          record: false
+          wait-on: "http://localhost:3000"
+          wait-on-timeout: 120
+          config: pageLoadTimeout=100000
+          browser: ${{ matrix.browser }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CYPRESS_auth_base_url: http://localhost:3000/auth
+          CYPRESS_controls_base_url: http://localhost:8081/controls
+          CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
+      - uses: actions/upload-artifact@v1
+        if: failure()
+        with:
+          name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
+          path: cypress/screenshots
+      - uses: actions/upload-artifact@v1
+        if: always()
+        with:
+          name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
+          path: cypress/videos

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -113,7 +113,7 @@ jobs:
           yarn install
           yarn build:instrumentation
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v2.8.2
         with:
           record: false
           start: yarn run ui:start
@@ -252,7 +252,7 @@ jobs:
           quay.io/konveyor/tackle-ui:main
           sleep 5s && docker logs tackle-ui
       - name: Cypress run
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v2.8.2
         with:
           record: false
           wait-on: "http://localhost:3000"

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -9,26 +9,26 @@ on:
       - main
 
 jobs:
-  # unit-test:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       node-version: [10.x, 12.x, 14.x]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js ${{ matrix.node-version }}
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: ${{ matrix.node-version }}
-  #     - name: Build
-  #       run: |
-  #         yarn install
-  #         yarn build
-  #     - name: Test
-  #       run: yarn test --coverage --watchAll=false
-  #     - uses: codecov/codecov-action@v1
-  #       with:
-  #         flags: unitests
+  unit-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Build
+        run: |
+          yarn install
+          yarn build
+      - name: Test
+        run: yarn test --coverage --watchAll=false
+      - uses: codecov/codecov-action@v1
+        with:
+          flags: unitests
 
   e2e:
     # needs: [unit-test]

--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -36,8 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        # browser: [chrome, firefox]
-        browser: [chrome]
+        browser: [chrome, firefox]
     services:
       keycloak:
         image: quay.io/keycloak/keycloak:12.0.2
@@ -114,7 +113,7 @@ jobs:
           yarn install
           yarn build:instrumentation
       - name: Cypress run
-        uses: cypress-io/github-action@v2.8.2
+        uses: cypress-io/github-action@v2
         with:
           record: false
           start: yarn run ui:start
@@ -138,140 +137,140 @@ jobs:
         with:
           flags: e2etests
 
-  # container-images:
-  #   if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
-  #   runs-on: ubuntu-latest
-  #   needs: [unit-test, e2e]
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Use Node.js
-  #       uses: actions/setup-node@v1
-  #       with:
-  #         node-version: 12.x
-  #     - name: Build
-  #       run: |
-  #         yarn install
-  #         yarn build
-  #     - name: Push to Quay.io
-  #       uses: elgohr/Publish-Docker-Github-Action@3.02
-  #       with:
-  #         registry: quay.io
-  #         name: konveyor/tackle-ui
-  #         username: ${{ secrets.QUAYIO_USERNAME }}
-  #         password: ${{ secrets.QUAYIO_PASSWORD }}
-  #         dockerfile: Dockerfile
-  #         snapshot: false
-  #         tags: "main"
+   container-images:
+     if: ${{ github.event_name != 'pull_request' && github.repository_owner == 'konveyor' }}
+     runs-on: ubuntu-latest
+     needs: [unit-test, e2e]
+     steps:
+       - uses: actions/checkout@v2
+       - name: Use Node.js
+         uses: actions/setup-node@v1
+         with:
+           node-version: 12.x
+       - name: Build
+         run: |
+           yarn install
+           yarn build
+       - name: Push to Quay.io
+         uses: elgohr/Publish-Docker-Github-Action@3.02
+         with:
+           registry: quay.io
+           name: konveyor/tackle-ui
+           username: ${{ secrets.QUAYIO_USERNAME }}
+           password: ${{ secrets.QUAYIO_PASSWORD }}
+           dockerfile: Dockerfile
+           snapshot: false
+           tags: "main"
 
-  # test-container-images:
-  #   needs: [container-images]
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest]
-  #       browser: [chrome, firefox]
-  #   services:
-  #     keycloak:
-  #       image: quay.io/keycloak/keycloak:12.0.2
-  #       ports:
-  #         - 8180:8080
-  #       env:
-  #         KEYCLOAK_USER: admin
-  #         KEYCLOAK_PASSWORD: admin
-  #       options: >-
-  #         --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #     controls-db:
-  #       image: postgres:13.1
-  #       ports:
-  #         - 5433:5432
-  #       env:
-  #         POSTGRES_USER: user
-  #         POSTGRES_PASSWORD: password
-  #         POSTGRES_DB: controls_db
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #     application-inventory-db:
-  #       image: postgres:13.1
-  #       ports:
-  #         - 5434:5432
-  #       env:
-  #         POSTGRES_USER: user
-  #         POSTGRES_PASSWORD: password
-  #         POSTGRES_DB: application_inventory_db
-  #       options: >-
-  #         --health-cmd pg_isready
-  #         --health-interval 10s
-  #         --health-timeout 5s
-  #         --health-retries 5
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - name: Keycloak Admin CLI
-  #       uses: carlosthe19916/keycloak-action@0.4
-  #       with:
-  #         server: http://keycloak:8080/auth
-  #         username: admin
-  #         password: admin
-  #         kcadm: create realms -f konveyor-realm.json
-  #     - name: Controls API
-  #       run: |
-  #         docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
-  #         -e QUARKUS_HTTP_PORT=8080 \
-  #         -e QUARKUS_DATASOURCE_USERNAME=user \
-  #         -e QUARKUS_DATASOURCE_PASSWORD=password \
-  #         -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
-  #         -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-  #         -e QUARKUS_OIDC_CLIENT_ID=controls-api \
-  #         -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-  #         quay.io/konveyor/tackle-controls:latest-native
-  #         sleep 5s && docker logs controls
-  #     - name: Application inventory API
-  #       run: |
-  #         docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
-  #         -e QUARKUS_HTTP_PORT=8080 \
-  #         -e QUARKUS_DATASOURCE_USERNAME=user \
-  #         -e QUARKUS_DATASOURCE_PASSWORD=password \
-  #         -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
-  #         -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
-  #         -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
-  #         -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
-  #         quay.io/konveyor/tackle-application-inventory:latest-native
-  #         sleep 5s && docker logs application-inventory
-  #     - name: Tackle UI
-  #       run: |
-  #         docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
-  #         -e SSO_REALM=konveyor \
-  #         -e SSO_CLIENT_ID=tackle-ui \
-  #         -e SSO_SERVER_URL=http://keycloak:8080/auth \
-  #         -e CONTROLS_API_URL=http://controls:8080/controls \
-  #         -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
-  #         quay.io/konveyor/tackle-ui:main
-  #         sleep 5s && docker logs tackle-ui
-  #     - name: Cypress run
-  #       uses: cypress-io/github-action@v2.8.2
-  #       with:
-  #         record: false
-  #         wait-on: "http://localhost:3000"
-  #         wait-on-timeout: 120
-  #         config: pageLoadTimeout=100000
-  #         browser: ${{ matrix.browser }}
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #         CYPRESS_auth_base_url: http://localhost:3000/auth
-  #         CYPRESS_controls_base_url: http://localhost:8081/controls
-  #         CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
-  #     - uses: actions/upload-artifact@v1
-  #       if: failure()
-  #       with:
-  #         name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
-  #         path: cypress/screenshots
-  #     - uses: actions/upload-artifact@v1
-  #       if: always()
-  #       with:
-  #         name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
-  #         path: cypress/videos
+   test-container-images:
+     needs: [container-images]
+     runs-on: ubuntu-latest
+     strategy:
+       matrix:
+         os: [ubuntu-latest]
+         browser: [chrome, firefox]
+     services:
+       keycloak:
+         image: quay.io/keycloak/keycloak:12.0.2
+         ports:
+           - 8180:8080
+         env:
+           KEYCLOAK_USER: admin
+           KEYCLOAK_PASSWORD: admin
+         options: >-
+           --health-cmd "curl --fail http://localhost:8080/auth || exit 1"
+           --health-interval 10s
+           --health-timeout 5s
+           --health-retries 5
+       controls-db:
+         image: postgres:13.1
+         ports:
+           - 5433:5432
+         env:
+           POSTGRES_USER: user
+           POSTGRES_PASSWORD: password
+           POSTGRES_DB: controls_db
+         options: >-
+           --health-cmd pg_isready
+           --health-interval 10s
+           --health-timeout 5s
+           --health-retries 5
+       application-inventory-db:
+         image: postgres:13.1
+         ports:
+           - 5434:5432
+         env:
+           POSTGRES_USER: user
+           POSTGRES_PASSWORD: password
+           POSTGRES_DB: application_inventory_db
+         options: >-
+           --health-cmd pg_isready
+           --health-interval 10s
+           --health-timeout 5s
+           --health-retries 5
+     steps:
+       - uses: actions/checkout@v2
+       - name: Keycloak Admin CLI
+         uses: carlosthe19916/keycloak-action@0.4
+         with:
+           server: http://keycloak:8080/auth
+           username: admin
+           password: admin
+           kcadm: create realms -f konveyor-realm.json
+       - name: Controls API
+         run: |
+           docker run -d --name controls --network ${{ job.services.controls-db.network }} --network-alias controls -p 8081:8080 \
+           -e QUARKUS_HTTP_PORT=8080 \
+           -e QUARKUS_DATASOURCE_USERNAME=user \
+           -e QUARKUS_DATASOURCE_PASSWORD=password \
+           -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://controls-db:5432/controls_db \
+           -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+           -e QUARKUS_OIDC_CLIENT_ID=controls-api \
+           -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+           quay.io/konveyor/tackle-controls:latest-native
+           sleep 5s && docker logs controls
+       - name: Application inventory API
+         run: |
+           docker run -d --name application-inventory --network ${{ job.services.application-inventory-db.network }} --network-alias application-inventory -p 8082:8080 \
+           -e QUARKUS_HTTP_PORT=8080 \
+           -e QUARKUS_DATASOURCE_USERNAME=user \
+           -e QUARKUS_DATASOURCE_PASSWORD=password \
+           -e QUARKUS_DATASOURCE_JDBC_URL=jdbc:postgresql://application-inventory-db:5432/application_inventory_db \
+           -e QUARKUS_OIDC_AUTH_SERVER_URL=http://keycloak:8080/auth/realms/konveyor \
+           -e QUARKUS_OIDC_CLIENT_ID=application-inventory-api \
+           -e QUARKUS_OIDC_CREDENTIALS_SECRET=secret \
+           quay.io/konveyor/tackle-application-inventory:latest-native
+           sleep 5s && docker logs application-inventory
+       - name: Tackle UI
+         run: |
+           docker run -d --name tackle-ui --network ${{ job.services.keycloak.network }} --network-alias tackle-ui -p 3000:8080 \
+           -e SSO_REALM=konveyor \
+           -e SSO_CLIENT_ID=tackle-ui \
+           -e SSO_SERVER_URL=http://keycloak:8080/auth \
+           -e CONTROLS_API_URL=http://controls:8080/controls \
+           -e APPLICATION_INVENTORY_API_URL=http://application-inventory:8080/application-inventory \
+           quay.io/konveyor/tackle-ui:main
+           sleep 5s && docker logs tackle-ui
+       - name: Cypress run
+         uses: cypress-io/github-action@v2
+         with:
+           record: false
+           wait-on: "http://localhost:3000"
+           wait-on-timeout: 120
+           config: pageLoadTimeout=100000
+           browser: ${{ matrix.browser }}
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           CYPRESS_auth_base_url: http://localhost:3000/auth
+           CYPRESS_controls_base_url: http://localhost:8081/controls
+           CYPRESS_application_inventory_base_url: http://localhost:8082/application-inventory
+       - uses: actions/upload-artifact@v1
+         if: failure()
+         with:
+           name: container-screenshots-${{ matrix.os }}-${{ matrix.browser }}
+           path: cypress/screenshots
+       - uses: actions/upload-artifact@v1
+         if: always()
+         with:
+           name: container-videos-${{ matrix.os }}-${{ matrix.browser }}
+           path: cypress/videos

--- a/cypress.json
+++ b/cypress.json
@@ -7,7 +7,7 @@
     "controls_base_url": "http://localhost:8081/controls",
     "application_inventory_base_url": "http://localhost:8082/application-inventory"
   },
-  "viewportWidth": 1225,
-  "viewportHeight": 886,
+  "viewportWidth": 1280,
+  "viewportHeight": 1024,
   "chromeWebSecurity": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -6,8 +6,5 @@
     "auth_client_id": "tackle-ui",
     "controls_base_url": "http://localhost:8081/controls",
     "application_inventory_base_url": "http://localhost:8082/application-inventory"
-  },
-  "viewportWidth": 1280,
-  "viewportHeight": 1024,
-  "chromeWebSecurity": false
+  }
 }

--- a/cypress.json
+++ b/cypress.json
@@ -7,5 +7,8 @@
     "auth_client_id": "tackle-ui",
     "controls_base_url": "http://localhost:8081/controls",
     "application_inventory_base_url": "http://localhost:8082/application-inventory"
-  }
+  },
+  "viewportWidth": 1280,
+  "viewportHeight": 1024,
+  "chromeWebSecurity": false
 }

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,5 @@
 {
+  "video": false,
   "baseUrl": "http://localhost:3000/",
   "env": {
     "auth_base_url": "http://localhost:8180/auth",

--- a/cypress.json
+++ b/cypress.json
@@ -1,5 +1,4 @@
 {
-  "video": false,
   "baseUrl": "http://localhost:3000/",
   "env": {
     "auth_base_url": "http://localhost:8180/auth",

--- a/cypress/integration/controls/stakeholder/stakeholderList.test.js
+++ b/cypress/integration/controls/stakeholder/stakeholderList.test.js
@@ -213,6 +213,55 @@ context("Test business service list", () => {
       .should("contain", "myDisplayName");
   });
 
+  it.only("Create new", () => {
+    cy.intercept({
+      method: "GET",
+      url: "/api/controls/stakeholder",
+    }).as("apiCheckGetStakeholders");
+
+    cy.intercept({
+      method: "GET",
+      url: "/api/controls/job-function",
+    }).as("apiCheckGetJobFunction");
+
+    cy.visit("/controls/stakeholders");
+
+    // Open modal
+    cy.get("button[aria-label='create-stakeholder']").click();
+
+    // Verify primary button is disabled
+    cy.get("button[aria-label='submit']").should("be.disabled");
+
+    // Fill form
+    cy.wait("@apiCheckGetJobFunction");
+
+    cy.get("input[name='email']").type("aaa@domain.com");
+    cy.get("input[name='displayName']").type("myDisplayName");
+
+    cy.get(".pf-c-form__group-control button.pf-c-select__toggle-button")
+      .eq(0)
+      .click();
+    cy.get(
+      ".pf-c-form__group-control .pf-c-form-control.pf-c-select__toggle-typeahead"
+    )
+      .eq(0)
+      .type("Business Analyst");
+    cy.get("button.pf-c-select__menu-item")
+      .eq(0)
+      .click({ waitForAnimations: false });
+
+    cy.get("button[aria-label='submit']").should("not.be.disabled");
+    cy.get("form").submit();
+
+    cy.wait("@apiCheckGetStakeholders");
+
+    // Verify table
+    cy.get("tbody > tr")
+      .should("contain", "aaa@domain.com")
+      .should("contain", "myDisplayName")
+      .should("contain", "Business Analyst");
+  });
+
   it("Edit", () => {
     cy.intercept({
       method: "GET",

--- a/cypress/integration/controls/stakeholder/stakeholderList.test.js
+++ b/cypress/integration/controls/stakeholder/stakeholderList.test.js
@@ -213,7 +213,7 @@ context("Test business service list", () => {
       .should("contain", "myDisplayName");
   });
 
-  it.only("Create new", () => {
+  it("Create new", () => {
     cy.intercept({
       method: "GET",
       url: "/api/controls/stakeholder",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,13 @@ services:
       QUARKUS_OIDC_CLIENT_ID: application-inventory-api
       QUARKUS_OIDC_CREDENTIALS_SECRET: secret
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8080/application-inventory/q/health"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:8080/application-inventory/q/health",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -92,4 +98,25 @@ services:
       application-inventory-db:
         condition: service_healthy
 
-  
+  ui:
+    image: quay.io/konveyor/tackle-ui:main
+    ports:
+      - 3001:8080
+    environment:
+      SSO_REALM: konveyor
+      SSO_CLIENT_ID: tackle-ui
+      SSO_SERVER_URL: http://keycloak:8080/auth
+      CONTROLS_API_URL: http://controls:8080/controls
+      APPLICATION_INVENTORY_API_URL: http://application-inventory:8080/application-inventory
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      keycloak:
+        condition: service_healthy
+      controls:
+        condition: service_healthy
+      application-inventory:
+        condition: service_healthy

--- a/konveyor-realm.json
+++ b/konveyor-realm.json
@@ -952,10 +952,12 @@
         "clientAuthenticatorType": "client-secret",
         "secret": "**********",
         "redirectUris": [
-          "http://localhost:3000/*"
+          "http://localhost:3000/*",
+          "http://localhost:3001/*"
         ],
         "webOrigins": [
-          "http://localhost:3000"
+          "http://localhost:3000",
+          "http://localhost:3001"
         ],
         "notBefore": 0,
         "bearerOnly": false,

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@types/redux-logger": "^3.0.8",
     "@types/yup": "^0.29.11",
     "axios-mock-adapter": "^1.19.0",
-    "cypress": "6.5.0",
+    "cypress": "6.7.0",
     "cypress-keycloak-commands": "^1.2.0",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.5",

--- a/src/pages/controls/stakeholders/stakeholders.tsx
+++ b/src/pages/controls/stakeholders/stakeholders.tsx
@@ -214,7 +214,7 @@ export const Stakeholders: React.FC = () => {
           title: item.displayName,
         },
         {
-          title: item.jobFunction,
+          title: item.jobFunction?.role,
         },
         {
           title: item.groups ? item.groups.length : 0,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6939,10 +6939,10 @@ cypress-keycloak-commands@^1.2.0:
   resolved "https://registry.yarnpkg.com/cypress-keycloak-commands/-/cypress-keycloak-commands-1.2.0.tgz#7f241e8e104ebd389f9a844966dcca43694d0645"
   integrity sha512-j0THu0XMVlWah7YjDoVlFg2bIwSiBSda6g5Pm8HpC/9U2Glk0Hrp4yLggoseft3ThAlrpIkoLaIKMDbmvtgicw==
 
-cypress@6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.5.0.tgz#d853d7a8f915f894249a8788294bfba077278c17"
-  integrity sha512-ol/yTAqHrQQpYBjxLlRSvZf4DOb9AhaQNVlwdOZgJcBHZOOa52/p/6/p3PPcvzjWGOMG6Yq0z4G+jrbWyk/9Dg==
+cypress@6.7.0:
+  version "6.7.0"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-6.7.0.tgz#06e5bec43bd1e6f277532f29f8fe9bcccbb372e7"
+  integrity sha512-d1tEF7W4O2Hs68/OxFt5BpnQJVfix8Kjm1kgTIQHxdbtowjiU9ltVRfSPrMfvK/1SGttCUj+3I+o1EuxSo5Asg==
   dependencies:
     "@cypress/listr-verbose-renderer" "^0.4.1"
     "@cypress/request" "^2.88.5"
@@ -6977,7 +6977,7 @@ cypress@6.5.0:
     moment "^2.29.1"
     ospath "^1.2.2"
     pretty-bytes "^5.4.1"
-    ramda "~0.26.1"
+    ramda "~0.27.1"
     request-progress "^3.0.0"
     supports-color "^7.2.0"
     tmp "~0.2.1"
@@ -14937,10 +14937,10 @@ ramda@^0.21.0:
   resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.21.0.tgz#a001abedb3ff61077d4ff1d577d44de77e8d0a35"
   integrity sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=
 
-ramda@~0.26.1:
-  version "0.26.1"
-  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.26.1.tgz#8d41351eb8111c55353617fc3bbffad8e4d35d06"
-  integrity sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+ramda@~0.27.1:
+  version "0.27.1"
+  resolved "https://registry.yarnpkg.com/ramda/-/ramda-0.27.1.tgz#66fc2df3ef873874ffc2da6aa8984658abacf5c9"
+  integrity sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw==
 
 randexp@0.4.6:
   version "0.4.6"


### PR DESCRIPTION
The job function type changed in https://github.com/konveyor/tackle-controls/commit/581198e909c0b499e8c8ef4c3c9ac48d324863f9#diff-966ded9f5c0811fa3c67757f779d46824f641eafc0650a2e90161d51fbf21a65

from `String` to `Object` and it creates a bug when the UI is deployed with the latest changes of the `tackle-controls` image. This PR changes the UI way of showing the `JobFunction` too

- This PR is also upgrading cypres to `6.7.0` due to errors creating the Videos while executing the e2e tests. The error appeared a couple of days ago since the GH action we are using upgraded Chrome from `88` to `89`. For references regarding this bug see https://github.com/cypress-io/cypress/issues/3491#issuecomment-789602268
- This PR is also enhancing the docker-compose.yml file so it also deploys the UI and it is easy to deploy all layers of the Tackle protect without needing to deploy it to K8s. This is meant to be used only on Dev environments.