### PR TITLE
Enable firefox in the e2e tests comming from PRs

### DIFF
--- a/.github/workflows/ci-actions.yml
+++ b/.github/workflows/ci-actions.yml
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        browser: [chrome]
+        browser: [chrome, firefox]
     services:
       keycloak:
         image: quay.io/keycloak/keycloak:12.0.2


### PR DESCRIPTION
Right now the firefox tests are being executed only in the GH step `test-container-images` and not in the step `e2e` of the GH action definition. This PRs adds firefox execution for PRs