### PR TITLE
Add sorting capabilities to the command 'yarn extract'

### DIFF
--- a/i18next-parser.config.js
+++ b/i18next-parser.config.js
@@ -20,5 +20,6 @@ module.exports = {
 
   input: ["src/**/*.{js,jsx,ts,tsx}"],
 
+  sort: true,
   verbose: true,
 };

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm run extract"
+      "pre-commit": "npm run extract && lint-staged"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged",
-      "pre-push": "npm run extract"
+      "post-commit": "npm run extract"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run extract && lint-staged"
+      "pre-commit": "lint-staged",
+      "post-commit": "npm run extract"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tackle-ui",
-  "version": "0.1",
+  "version": "0.1.0",
   "private": true,
   "dependencies": {
     "@konveyor/lib-ui": "^2.0.0",
@@ -108,7 +108,8 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged"
+      "pre-commit": "lint-staged",
+      "pre-push": "npm run extract"
     }
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -108,8 +108,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged",
-      "post-commit": "npm run extract"
+      "pre-commit": "lint-staged && npm run extract"
     }
   },
   "lint-staged": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,72 +1,72 @@
 {
+    "actions": {
+        "cancel": "Cancel",
+        "create": "Create",
+        "createNew": "Create new",
+        "delete": "Delete",
+        "edit": "Edit",
+        "save": "Save"
+    },
+    "composed": {
+        "applicationInventory": "Application inventory",
+        "noDataStateBody": "Create a new {{what}} to start seeing data here",
+        "noDataStateTitle": "No {{what}} available",
+        "selectMany": "Select {{what}}",
+        "selectOne": "Select a {{what}}"
+    },
+    "dialog": {
+        "message": {
+            "delete": "Are you sure you want to delete '{{what}}'? This will delete all resources associated with it and cannot be undone. Make sure this is something you really want to do!"
+        },
+        "title": {
+            "delete": "Delete '{{what}}'",
+            "newApplication": "New application",
+            "newBusinessService": "New business service",
+            "newStakeholder": "New stakeholder",
+            "newStakeholderGroup": "New stakeholder group",
+            "updateApplication": "Update application",
+            "updateBusinessService": "Update business service",
+            "updateStakeholder": "Update stakeholder",
+            "updateStakeholderGroup": "Update stakeholder group"
+        }
+    },
     "sidebar": {
         "applicationInventory": "Application inventory",
-        "reports": "Reports",
-        "controls": "Controls"
+        "controls": "Controls",
+        "reports": "Reports"
     },
     "terms": {
         "application": "Application",
         "applications": "Applications",
-        "name": "Name",
-        "description": "Description",
-        "comments": "Comments",
-        "unknown": "Unknown",
         "businessService": "Business service",
-        "owner": "Owner",
-        "controls": "Controls",
-        "stakeholders": "Stakeholders",
-        "stakeholderGroups": "Stakeholder groups",
         "businessServices": "Business services",
-        "tags": "Tags",
-        "member(s)": "Member(s)",
-        "member": "Member",
-        "email": "Email",
+        "comments": "Comments",
+        "controls": "Controls",
+        "description": "Description",
         "displayName": "Display name",
-        "jobFunction": "Job function",
+        "email": "Email",
+        "group": "Group",
         "group(s)": "Group(s)",
-        "group": "Group"
-    },
-    "actions": {
-        "edit": "Edit",
-        "delete": "Delete",
-        "cancel": "Cancel",
-        "createNew": "Create new",
-        "create": "Create",
-        "save": "Save"
-    },
-    "dialog": {
-        "title": {
-            "delete": "Delete '{{what}}'",
-            "newApplication": "New application",
-            "updateApplication": "Update application",
-            "newBusinessService": "New business service",
-            "updateBusinessService": "Update business service",
-            "newStakeholderGroup": "New stakeholder group",
-            "updateStakeholderGroup": "Update stakeholder group",
-            "newStakeholder": "New stakeholder",
-            "updateStakeholder": "Update stakeholder"
-        },
-        "message": {
-            "delete": "Are you sure you want to delete '{{what}}'? This will delete all resources associated with it and cannot be undone. Make sure this is something you really want to do!"
-        }
+        "jobFunction": "Job function",
+        "member": "Member",
+        "member(s)": "Member(s)",
+        "name": "Name",
+        "owner": "Owner",
+        "stakeholderGroups": "Stakeholder groups",
+        "stakeholders": "Stakeholders",
+        "tags": "Tags",
+        "unknown": "Unknown"
     },
     "toastr": {
         "success": {
             "added": "Success! {{what}} was added as a {{type}}."
         }
     },
-    "composed": {
-        "applicationInventory": "Application inventory",
-        "noDataStateTitle": "No {{what}} available",
-        "noDataStateBody": "Create a new {{what}} to start seeing data here",
-        "selectOne": "Select a {{what}}",
-        "selectMany": "Select {{what}}"
-    },
     "validation": {
-        "required": "This field is required.",
-        "minLength": "This field must contain at least {{length}} characters.",
+        "email": "This field requires a valid email.",
         "maxLength": "This field must contain fewer than {{length}} characters.",
+        "minLength": "This field must contain at least {{length}} characters.",
         "onlyCharactersAndUnderscore": "This field must contain only alphanumeric characters including underscore.",
-        "email": "This field requires a valid email."
+        "required": "This field is required."
     }
 }

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,5 +1,6 @@
 {
     "actions": {
+        "zzz": "this should go to bottom",
         "cancel": "Cancel",
         "create": "Create",
         "createNew": "Create new",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -1,6 +1,5 @@
 {
     "actions": {
-        "zzz": "this should go to bottom",
         "cancel": "Cancel",
         "create": "Create",
         "createNew": "Create new",

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -11,7 +11,6 @@
         "applicationInventory": "Application inventory",
         "noDataStateBody": "Create a new {{what}} to start seeing data here",
         "noDataStateTitle": "No {{what}} available",
-        "selectMany": "Select {{what}}",
         "selectOne": "Select a {{what}}"
     },
     "dialog": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,10 +1,10 @@
 {
     "actions": {
         "cancel": "Cancelar",
-        "create": "Crear",
         "createNew": "Crear nuevo",
         "delete": "Eliminar",
         "edit": "Editar",
+        "create": "Crear",
         "save": "Guardar"
     },
     "composed": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,10 +1,10 @@
 {
     "actions": {
         "cancel": "Cancelar",
+        "create": "Crear",
         "createNew": "Crear nuevo",
         "delete": "Eliminar",
         "edit": "Editar",
-        "create": "Crear",
         "save": "Guardar"
     },
     "composed": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -11,7 +11,6 @@
         "applicationInventory": "Inventario de aplicaciones",
         "noDataStateBody": "Cree un(a) nuevo(a) {{what}} para empezar a ver datos acá",
         "noDataStateTitle": "No existen {{what}} disponibles",
-        "selectMany": "Seleccione {{what}}",
         "selectOne": "Seleccione un(a) {{what}}"
     },
     "dialog": {

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,72 +1,72 @@
 {
+    "actions": {
+        "cancel": "Cancelar",
+        "create": "Crear",
+        "createNew": "Crear nuevo",
+        "delete": "Eliminar",
+        "edit": "Editar",
+        "save": "Guardar"
+    },
+    "composed": {
+        "applicationInventory": "Inventario de aplicaciones",
+        "noDataStateBody": "Cree un(a) nuevo(a) {{what}} para empezar a ver datos acá",
+        "noDataStateTitle": "No existen {{what}} disponibles",
+        "selectMany": "Seleccione {{what}}",
+        "selectOne": "Seleccione un(a) {{what}}"
+    },
+    "dialog": {
+        "message": {
+            "delete": "¿Estás seguro de querer eliminar '{{what}}'?. Esta acción eliminará todos los recursos asociados al mismo y no puede ser revertida. ¡Asegúrate de que esto es lo que realmente quieres!"
+        },
+        "title": {
+            "delete": "Eliminar '{{what}}'",
+            "newApplication": "Nueva aplicación",
+            "newBusinessService": "Nuevo servicio de negocio",
+            "newStakeholder": "Nuevo interesado",
+            "newStakeholderGroup": "Nuevo grupo de interesados",
+            "updateApplication": "Actualizar aplicación",
+            "updateBusinessService": "Actualizar servicio de negocio",
+            "updateStakeholder": "Actualizar interesado",
+            "updateStakeholderGroup": "Actualizar grupo de interesados"
+        }
+    },
     "sidebar": {
         "applicationInventory": "Inventario de aplicaciones",
-        "reports": "Reportes",
-        "controls": "Controles"
+        "controls": "Controles",
+        "reports": "Reportes"
     },
     "terms": {
         "application": "Applicación",
         "applications": "Applicaciones",
-        "name": "Nombre",
-        "description": "Descripción",
-        "comments": "Comentarios",
-        "unknown": "Desconocido",
         "businessService": "Servicio de negocio",
-        "owner": "Propietario",
-        "controls": "Controles",
-        "stakeholders": "Interesados",
-        "stakeholderGroups": "Grupos de interesados",
         "businessServices": "Servicios de negocio",
-        "tags": "Etiquetas",
-        "member(s)": "Miembro(s)",
-        "member": "Miembro",
-        "email": "Email",
+        "comments": "Comentarios",
+        "controls": "Controles",
+        "description": "Descripción",
         "displayName": "Nombre a mostrar",
-        "jobFunction": "Función laboral",
+        "email": "Email",
+        "group": "Grupo",
         "group(s)": "Grupo(s)",
-        "group": "Grupo"
-    },
-    "actions": {
-        "edit": "Editar",
-        "delete": "Eliminar",
-        "cancel": "Cancelar",
-        "createNew": "Crear nuevo",
-        "create": "Crear",
-        "save": "Guardar"
-    },
-    "dialog": {
-        "title": {
-            "delete": "Eliminar '{{what}}'",
-            "newApplication": "Nueva aplicación",
-            "updateApplication": "Actualizar aplicación",
-            "newBusinessService": "Nuevo servicio de negocio",
-            "updateBusinessService": "Actualizar servicio de negocio",
-            "newStakeholderGroup": "Nuevo grupo de interesados",
-            "updateStakeholderGroup": "Actualizar grupo de interesados",
-            "newStakeholder": "Nuevo interesado",
-            "updateStakeholder": "Actualizar interesado"
-        },
-        "message": {
-            "delete": "¿Estás seguro de querer eliminar '{{what}}'?. Esta acción eliminará todos los recursos asociados al mismo y no puede ser revertida. ¡Asegúrate de que esto es lo que realmente quieres!"
-        }
+        "jobFunction": "Función laboral",
+        "member": "Miembro",
+        "member(s)": "Miembro(s)",
+        "name": "Nombre",
+        "owner": "Propietario",
+        "stakeholderGroups": "Grupos de interesados",
+        "stakeholders": "Interesados",
+        "tags": "Etiquetas",
+        "unknown": "Desconocido"
     },
     "toastr": {
         "success": {
             "added": "Éxito! {{what}} fue creado como un {{type}}."
         }
     },
-    "composed": {
-        "applicationInventory": "Inventario de aplicaciones",
-        "noDataStateTitle": "No existen {{what}} disponibles",
-        "noDataStateBody": "Cree un(a) nuevo(a) {{what}} para empezar a ver datos acá",
-        "selectOne": "Seleccione un(a) {{what}}",
-        "selectMany": "Seleccione {{what}}"
-    },
     "validation": {
-        "required": "Este campo es requerido.",
-        "minLength": "Este campo debe de tener al menos {{length}} caracteres.",
+        "email": "Este campo requiere un email válido.",
         "maxLength": "Este campo debe de tener menos de {{length}} caracteres.",
+        "minLength": "Este campo debe de tener al menos {{length}} caracteres.",
         "onlyCharactersAndUnderscore": "Este campo debe de contener solo caracteres alfanuméricos incluyendo el subguión.",
-        "email": "Este campo requiere un email válido."
+        "required": "Este campo es requerido."
     }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,7 +1,7 @@
 {
     "actions": {
-        "create": "Crear",
         "cancel": "Cancelar",
+        "create": "Crear",
         "createNew": "Crear nuevo",
         "delete": "Eliminar",
         "edit": "Editar",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,7 +1,7 @@
 {
     "actions": {
-        "cancel": "Cancelar",
         "create": "Crear",
+        "cancel": "Cancelar",
         "createNew": "Crear nuevo",
         "delete": "Eliminar",
         "edit": "Editar",

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -13,6 +13,8 @@ i18n
     interpolation: {
       escapeValue: false,
     },
+
+    returnEmptyString: false,
   });
 
 export default i18n;

--- a/src/pages/application-inventory/application-inventory.tsx
+++ b/src/pages/application-inventory/application-inventory.tsx
@@ -410,9 +410,11 @@ export const ApplicationInventory: React.FC = () => {
             }
             noDataState={
               <NoDataEmptyState
+                // t('terms.applications')
                 title={t("composed.noDataStateTitle", {
                   what: t("terms.applications").toLowerCase(),
                 })}
+                // t('terms.application')
                 description={t("composed.noDataStateBody", {
                   what: t("terms.application").toLowerCase(),
                 })}

--- a/src/pages/application-inventory/application-inventory.tsx
+++ b/src/pages/application-inventory/application-inventory.tsx
@@ -90,9 +90,6 @@ export const ApplicationInventory: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const testing = t("actions.zzzzzz");
-  console.log(testing);
-
   const filters = [
     {
       key: FilterKey.NAME,

--- a/src/pages/application-inventory/application-inventory.tsx
+++ b/src/pages/application-inventory/application-inventory.tsx
@@ -90,6 +90,9 @@ export const ApplicationInventory: React.FC = () => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
+  const testing = t("actions.zzzzzz");
+  console.log(testing);
+
   const filters = [
     {
       key: FilterKey.NAME,


### PR DESCRIPTION
This PR allows `yarn extract` to sort alphabetically all key values from the internationalization .json files.

Currently the command `yarn extract` is used to generate all key/values in the internationalization .json files. The current configuration doesn't sort the key/values in the .json files generating some conflicts when a new PR with new key/values comes.

This doesn't change any behavior or functionality of the UI but just adds a better way of organizing the content of the internationalization files.


https://user-images.githubusercontent.com/2582866/112620535-f67aa180-8e28-11eb-8179-dd37e8299ca2.mp4


https://user-images.githubusercontent.com/2582866/112623853-275cd580-8e2d-11eb-91e8-44fe4bb8f777.mp4

