### PR TITLE
Bump @patternfly/react-table from 4.23.3 to 4.24.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@konveyor/lib-ui": "^2.0.0",
     "@patternfly/patternfly": "4.96.2",
     "@patternfly/react-core": "4.97.3",
-    "@patternfly/react-table": "4.23.3",
+    "@patternfly/react-table": "4.24.1",
     "@react-keycloak/web": "^3.4.0",
     "@redhat-cloud-services/frontend-components-notifications": "3.0.3",
     "@testing-library/jest-dom": "^5.11.4",

--- a/src/shared/components/app-table/tests/__snapshots__/app-table.test.tsx.snap
+++ b/src/shared/components/app-table/tests/__snapshots__/app-table.test.tsx.snap
@@ -29,6 +29,7 @@ exports[`AppTable Renders without crashing 1`] = `
   expandId="expandable-toggle"
   gridBreakPoint="grid-md"
   isStickyHeader={false}
+  isTreeTable={false}
   ouiaSafe={true}
   role="grid"
   rowLabeledBy="simple-node"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2182,17 +2182,12 @@
   dependencies:
     mkdirp "^1.0.4"
 
-"@patternfly/patternfly@4.87.3":
-  version "4.87.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.87.3.tgz#eb2e9b22aa8f6f106580e7451bf204a06cb9949e"
-  integrity sha512-hDNMPa7B1zKD8LWFZO4SS5hC/N+yvuci2sAn8HJd+EIbAvbMAUkRsyZ0/XO3BG3RVtpSlgq7q8x1pAHC/FTFuA==
-
 "@patternfly/patternfly@4.96.2":
   version "4.96.2"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.96.2.tgz#a30d2f95fbb4e92635acdb112a3fda7e148c2b3d"
   integrity sha512-nxXLyAGVYubXdJ8XuSPDuPBuUbuY1XPyYYzkIg6AmWp/bLA5Fs1kqX32F4djjGgR1eOteqRz478W/CE7Xi5E4A==
 
-"@patternfly/react-core@4.97.3", "@patternfly/react-core@^4.97.3":
+"@patternfly/react-core@4.97.3":
   version "4.97.3"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.3.tgz#4bdb90024af28953432bc8980f5f865329963b99"
   integrity sha512-cEZld3HSVaTxUwfbQXCVVnECYOtUKErQiAwCdMItOOFQLvZT0tcunsA7fFszugukvdiMfvk+Qo8kGTR09WDH0A==
@@ -2205,26 +2200,48 @@
     tippy.js "5.1.2"
     tslib "1.13.0"
 
+"@patternfly/react-core@^4.106.2":
+  version "4.106.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.106.2.tgz#c2796b06777e9223851a7b58d5567afa265456aa"
+  integrity sha512-zOws2Zqar1dxeKK0TJ2FPffXFnV1qfEpzPvEzBTCRr94vOLsoXbYETe8dsY2SDc7nN6IgP0npesYua9BIHVk6Q==
+  dependencies:
+    "@patternfly/react-icons" "^4.9.9"
+    "@patternfly/react-styles" "^4.9.4"
+    "@patternfly/react-tokens" "^4.10.9"
+    focus-trap "6.2.2"
+    react-dropzone "9.0.0"
+    tippy.js "5.1.2"
+    tslib "1.13.0"
+
 "@patternfly/react-icons@^4.9.2":
   version "4.9.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.2.tgz#dcb2efa9727de97d5aa5d6be47a75daee49addb8"
   integrity sha512-3PY81A9mj9YyUpznSWhcWMKHRyGWNgZ1IDYqbMva7Q8wgd0fjsiTJ+5zAp4YQLo1mA8KwYX9v5s37hK8XiTbAA==
+
+"@patternfly/react-icons@^4.9.9":
+  version "4.9.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.9.tgz#a10835cb5bdd482ab4de4651426e806382080129"
+  integrity sha512-TAWwmpYPZeseoQXXFdWgakB8UV5mf/FugH15D9C3PQoX+un4OI2nm7d689ItlmBfB3FLK9sMhZ2eZX7/tAjC9g==
 
 "@patternfly/react-styles@^4.8.2":
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
   integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
 
-"@patternfly/react-table@4.23.3":
-  version "4.23.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.23.3.tgz#2125922b4090ebddb9e50116f27a26860c3578b0"
-  integrity sha512-mjJ5y17yOUuqJmmdu2J9yT28C/bOu0IKRoEd9Pc1Nf8Jwa5x9rxUC8RyfY5QXaM9VhMoxSR3r3VJz16bc11CFQ==
+"@patternfly/react-styles@^4.9.4":
+  version "4.9.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.9.4.tgz#89b1a340d2a33fab225c8990f5f5047b4841dbfb"
+  integrity sha512-ysx9vqP+pDdKLbaS/y5UySsuYlsKznrNQs1/2QaDxdHgMY2wRhsCSROz2vyERqJerPxytz3TGAXFV7TOKWGIng==
+
+"@patternfly/react-table@4.24.1":
+  version "4.24.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-4.24.1.tgz#c5f008c7a1dc9e9f7e6c8e4767384e990da314bd"
+  integrity sha512-KVGg47wWlUQpl4ZxpIxdgjIbQnSg+asPzksk/4YDN+J9iO/70mq+7eYIxX3nyJuhXjKyZn6+o1nqpoJWzhKyBw==
   dependencies:
-    "@patternfly/patternfly" "4.87.3"
-    "@patternfly/react-core" "^4.97.3"
-    "@patternfly/react-icons" "^4.9.2"
-    "@patternfly/react-styles" "^4.8.2"
-    "@patternfly/react-tokens" "^4.10.2"
+    "@patternfly/react-core" "^4.106.2"
+    "@patternfly/react-icons" "^4.9.9"
+    "@patternfly/react-styles" "^4.9.4"
+    "@patternfly/react-tokens" "^4.10.9"
     lodash "^4.17.19"
     tslib "1.13.0"
 
@@ -2232,6 +2249,11 @@
   version "4.10.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
   integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
+
+"@patternfly/react-tokens@^4.10.9":
+  version "4.10.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.9.tgz#0c55ec18651bc8ca11f7bac10a4904e435e7e98d"
+  integrity sha512-qmyTPHC/bO+rxCnfLKQZLkV5xLRS2QkB/9aoAdUZvBXpcGS7eX891sSipefwSxxWv+9F2v06zfhdmAhgT7T02g==
 
 "@pmmmwh/react-refresh-webpack-plugin@0.4.2":
   version "0.4.2"


### PR DESCRIPTION
- Replaces https://github.com/konveyor/tackle-ui/pull/77
- https://github.com/konveyor/tackle-ui/pull/77 can not be merged as it is since it requires to update `snapshot` tests.
