### PR TITLE
Bump @patternfly/react-core from 4.97.3 to 4.106.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@konveyor/lib-ui": "^2.0.0",
     "@patternfly/patternfly": "4.96.2",
-    "@patternfly/react-core": "4.97.3",
+    "@patternfly/react-core": "4.106.2",
     "@patternfly/react-table": "4.24.1",
     "@react-keycloak/web": "^3.4.0",
     "@redhat-cloud-services/frontend-components-notifications": "3.0.3",

--- a/src/shared/components/simple-pagination/tests/__snapshots__/simple-pagination.test.tsx.snap
+++ b/src/shared/components/simple-pagination/tests/__snapshots__/simple-pagination.test.tsx.snap
@@ -47,6 +47,7 @@ exports[`SimplePagination Renders without crashing 1`] = `
       "currPage": "Current page",
       "items": "",
       "itemsPerPage": "Items per page",
+      "ofWord": "of",
       "optionsToggle": "Items per page",
       "page": "",
       "paginationTitle": "Pagination",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2187,20 +2187,7 @@
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-4.96.2.tgz#a30d2f95fbb4e92635acdb112a3fda7e148c2b3d"
   integrity sha512-nxXLyAGVYubXdJ8XuSPDuPBuUbuY1XPyYYzkIg6AmWp/bLA5Fs1kqX32F4djjGgR1eOteqRz478W/CE7Xi5E4A==
 
-"@patternfly/react-core@4.97.3":
-  version "4.97.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.97.3.tgz#4bdb90024af28953432bc8980f5f865329963b99"
-  integrity sha512-cEZld3HSVaTxUwfbQXCVVnECYOtUKErQiAwCdMItOOFQLvZT0tcunsA7fFszugukvdiMfvk+Qo8kGTR09WDH0A==
-  dependencies:
-    "@patternfly/react-icons" "^4.9.2"
-    "@patternfly/react-styles" "^4.8.2"
-    "@patternfly/react-tokens" "^4.10.2"
-    focus-trap "6.2.2"
-    react-dropzone "9.0.0"
-    tippy.js "5.1.2"
-    tslib "1.13.0"
-
-"@patternfly/react-core@^4.106.2":
+"@patternfly/react-core@4.106.2", "@patternfly/react-core@^4.106.2":
   version "4.106.2"
   resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-4.106.2.tgz#c2796b06777e9223851a7b58d5567afa265456aa"
   integrity sha512-zOws2Zqar1dxeKK0TJ2FPffXFnV1qfEpzPvEzBTCRr94vOLsoXbYETe8dsY2SDc7nN6IgP0npesYua9BIHVk6Q==
@@ -2213,20 +2200,10 @@
     tippy.js "5.1.2"
     tslib "1.13.0"
 
-"@patternfly/react-icons@^4.9.2":
-  version "4.9.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.2.tgz#dcb2efa9727de97d5aa5d6be47a75daee49addb8"
-  integrity sha512-3PY81A9mj9YyUpznSWhcWMKHRyGWNgZ1IDYqbMva7Q8wgd0fjsiTJ+5zAp4YQLo1mA8KwYX9v5s37hK8XiTbAA==
-
 "@patternfly/react-icons@^4.9.9":
   version "4.9.9"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-4.9.9.tgz#a10835cb5bdd482ab4de4651426e806382080129"
   integrity sha512-TAWwmpYPZeseoQXXFdWgakB8UV5mf/FugH15D9C3PQoX+un4OI2nm7d689ItlmBfB3FLK9sMhZ2eZX7/tAjC9g==
-
-"@patternfly/react-styles@^4.8.2":
-  version "4.8.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-4.8.2.tgz#4796a77b658541d75d616e2e2a00fc5d7ec42bc7"
-  integrity sha512-JLVZTUYa8LIyASLvfiAgByLgNcg+OPkuXSh8Za5KdjqrBaNVQ3Wlul+oWQGwlGjbq7KSiyDg1oWemxOuLJH1VQ==
 
 "@patternfly/react-styles@^4.9.4":
   version "4.9.4"
@@ -2244,11 +2221,6 @@
     "@patternfly/react-tokens" "^4.10.9"
     lodash "^4.17.19"
     tslib "1.13.0"
-
-"@patternfly/react-tokens@^4.10.2":
-  version "4.10.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-4.10.2.tgz#fd0054379ac81c8490b901b5b8fb408263ce91fe"
-  integrity sha512-/G1MENPxVY7X9UUuieO79yfjJ3g6KjBUBsBQVKOQplCxuvcRCF1MpmQKAxfg9Yb804MbPY+IVzVD3c4u9S3Iww==
 
 "@patternfly/react-tokens@^4.10.9":
   version "4.10.9"


### PR DESCRIPTION
Replaces https://github.com/konveyor/tackle-ui/pull/78
