### PR TITLE
Allow sorting the application list by Review

### DIFF
--- a/src/api/rest.tsx
+++ b/src/api/rest.tsx
@@ -429,6 +429,7 @@ export const getTagById = (id: number | string): AxiosPromise<Tag> => {
 export enum ApplicationSortBy {
   NAME,
   TAGS,
+  REVIEW,
 }
 export interface ApplicationSortByQuery {
   field: ApplicationSortBy;
@@ -454,6 +455,9 @@ export const getApplications = (
         break;
       case ApplicationSortBy.TAGS:
         field = "tags.size()";
+        break;
+      case ApplicationSortBy.REVIEW:
+        field = "review.deleted,id";
         break;
       default:
         throw new Error("Could not define SortBy field name");

--- a/src/pages/application-inventory/application-list/application-list.tsx
+++ b/src/pages/application-inventory/application-list/application-list.tsx
@@ -92,6 +92,9 @@ const toSortByQuery = (
     case 2:
       field = ApplicationSortBy.NAME;
       break;
+    case 6:
+      field = ApplicationSortBy.REVIEW;
+      break;
     case 7:
       field = ApplicationSortBy.TAGS;
       break;
@@ -251,7 +254,7 @@ export const ApplicationList: React.FC = () => {
     { title: t("terms.description"), transforms: [cellWidth(25)] },
     { title: t("terms.businessService"), transforms: [cellWidth(20)] },
     { title: t("terms.assessment"), transforms: [cellWidth(10)] },
-    { title: t("terms.review"), transforms: [cellWidth(10)] },
+    { title: t("terms.review"), transforms: [sortable, cellWidth(10)] },
     { title: t("terms.tags"), transforms: [sortable, cellWidth(10)] },
     {
       title: "",


### PR DESCRIPTION
resolve #185 

Sorting based on `review.deleted` field and then on `[application.]id` to get consistent ordering within the 2 subsets (`Not started` and `Completed`).

Test image available quay.io/mrizzi/tackle-ui:review-sorting