### PR TITLE
[TACKLE-188]-Stakeholder display name does not have unique constraint check

### DIFF
--- a/src/pages/application-inventory/application-assessment/components/stakeholders-form/stakeholder-select.tsx
+++ b/src/pages/application-inventory/application-assessment/components/stakeholders-form/stakeholder-select.tsx
@@ -14,6 +14,9 @@ const stakeholderToOption = (
 ): OptionWithValue<Stakeholder> => ({
   value,
   toString: () => value.displayName,
+  props: {
+    description: value.email,
+  },
 });
 
 export interface IStakeholderSelectProps {

--- a/src/utils/model-utils.tsx
+++ b/src/utils/model-utils.tsx
@@ -36,13 +36,14 @@ export const toIBusinessServiceDropdownOptionWithValue = (
 // Stakeholder dropdown
 
 export interface IStakeholderDropdown
-  extends Pick<Stakeholder, "id" | "displayName"> {}
+  extends Pick<Stakeholder, "id" | "displayName" | "email"> {}
 
 export const toIStakeholderDropdown = (
   value: Stakeholder
 ): IStakeholderDropdown => ({
   id: value.id,
   displayName: value.displayName,
+  email: value.email,
 });
 
 export const toIStakeholderDropdownOptionWithValue = (
@@ -50,6 +51,9 @@ export const toIStakeholderDropdownOptionWithValue = (
 ): OptionWithValue<IStakeholderDropdown> => ({
   value,
   toString: () => value.displayName,
+  props: {
+    description: value.email,
+  },
 });
 
 // Stakeholder group dropdown


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-188
As requested in the ticket above: the dropdowns that show stakeholders should include the email so it is easy to differentiate between 2 stakeholders with the same name but different emails.

Here is the set of pages that are affected:

![Screenshot from 2021-06-22 12-22-56](https://user-images.githubusercontent.com/2582866/122908994-06851d00-d355-11eb-8681-385211ac683b.png)
![Screenshot from 2021-06-22 12-22-38](https://user-images.githubusercontent.com/2582866/122908997-071db380-d355-11eb-9e03-2d20101d25e9.png)
![Screenshot from 2021-06-22 12-22-22](https://user-images.githubusercontent.com/2582866/122909002-07b64a00-d355-11eb-96d6-984108da0943.png)
