### PR TITLE
[TACKLE-243]-Selecting all applications and then selecting 10 applications in adoption candidate distribution report does not work

### DIFF
--- a/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -86,7 +86,6 @@ export const AdoptionCandidateTable: React.FC = () => {
     toggleItemSelected: toggleApplicationSelected,
     selectAll: selectAllApplication,
     setSelectedItems: setSelectedRows,
-    selectMultiple: selectMultipleApplications,
   } = useContext(ApplicationSelectionContext);
 
   // Confidence
@@ -264,10 +263,7 @@ export const AdoptionCandidateTable: React.FC = () => {
               onSelectAll={selectAllApplication}
               onSelectNone={() => setSelectedRows([])}
               onSelectCurrentPage={() => {
-                selectMultipleApplications(
-                  pageItems.map((f) => f.application),
-                  true
-                );
+                setSelectedRows(pageItems.map((f) => f.application));
               }}
             />
           </ToolbarItem>


### PR DESCRIPTION
https://issues.redhat.com/browse/TACKLE-243

New behavior description with an example:
- There are 100 elements in the table
- The user is located on the 5th page; so the table shows the elements `50,51,52,...59`
- The user clicks on `Select page (10 elements)`
- The Table will select only the elements of the current page (10 elements). It means, the selected rows will be only `50,51,52,...59`

![Screenshot from 2021-06-22 15-14-52](https://user-images.githubusercontent.com/2582866/122930843-9d110880-d36c-11eb-9e3a-48961025b394.png)
