### PR TITLE
Dev docker-compose.yml: Add missing env variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,7 @@ services:
       QUARKUS_OIDC_AUTH_SERVER_URL: http://keycloak:8080/auth/realms/konveyor
       QUARKUS_OIDC_CLIENT_ID: application-inventory-api
       QUARKUS_OIDC_CREDENTIALS_SECRET: secret
+      IO_TACKLE_APPLICATIONINVENTORY_SERVICES_CONTROLS_SERVICE: controls:8080
     healthcheck:
       test:
         [


### PR DESCRIPTION
In order to be able to use the current `docker-compose.yml` for development purposes of the UI the container `application-inventory` needs to have a proper `IO_TACKLE_APPLICATIONINVENTORY_SERVICES_CONTROLS_SERVICE` env variable configured.

> The docker-compose.yml file is exclusively used during development.