### PR TITLE
Tag type table-expanded area: action buttons are not aligned to the right

### DIFF
--- a/src/pages/controls/tags/components/tag-table/tag-table.tsx
+++ b/src/pages/controls/tags/components/tag-table/tag-table.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useTranslation } from "react-i18next";
 
 import {
+  cellWidth,
   IActions,
   ICell,
   IRow,
@@ -36,7 +37,7 @@ export const TagTable: React.FC<TabTableProps> = ({
   const columns: ICell[] = [
     {
       title: t("terms.tagName"),
-      transforms: [],
+      transforms: [cellWidth(100)],
       cellFormatters: [],
       props: {
         className: styles.columnPadding,


### PR DESCRIPTION
Before:
![Screenshot from 2021-09-01 16-48-31](https://user-images.githubusercontent.com/2582866/131694305-8ebec81a-6bc3-4161-8d6f-6c4d2b2ca2f7.png)

After:
![Screenshot from 2021-09-01 16-40-31](https://user-images.githubusercontent.com/2582866/131694308-6e7124c0-5122-4c52-99a3-bd12c4849572.png)
