### PR TITLE
Reports: adoption candidate distribution - wrong sort by confidence

### DIFF
--- a/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -41,16 +41,16 @@ const compareToByColumn = (
       return a.application.name.localeCompare(b.application.name);
     case 2: // Criticality
       return (
-        (a.application.review?.businessCriticality || 0) -
-        (b.application.review?.businessCriticality || 0)
+        (a.application.review?.businessCriticality || -1) -
+        (b.application.review?.businessCriticality || -1)
       );
     case 3: // Priority
       return (
-        (a.application.review?.workPriority || 0) -
-        (b.application.review?.workPriority || 0)
+        (a.application.review?.workPriority || -1) -
+        (b.application.review?.workPriority || -1)
       );
     case 4: // Confidence
-      return (a.confidence || 0) - (b.confidence || 0);
+      return (a.confidence || -1) - (b.confidence || -1);
     case 5: // Effort
       const aEffortSortFactor = a.application.review
         ? EFFORT_ESTIMATE_LIST[a.application.review.effortEstimate]

--- a/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -31,34 +31,42 @@ export interface TableRowData {
   confidence?: number;
 }
 
-const compareToByColumn = (
+export enum ColumnIndex {
+  APP_NAME = 1,
+  CRITICALITY = 2,
+  PRIORITY = 3,
+  CONFIDENCE = 4,
+  EFFORT = 5,
+}
+
+export const compareToByColumn = (
   a: TableRowData,
   b: TableRowData,
   columnIndex?: number
 ) => {
   switch (columnIndex) {
-    case 1: // AppName
+    case ColumnIndex.APP_NAME: // AppName
       return a.application.name.localeCompare(b.application.name);
-    case 2: // Criticality
+    case ColumnIndex.CRITICALITY: // Criticality
       return (
         (a.application.review?.businessCriticality ?? -1) -
         (b.application.review?.businessCriticality ?? -1)
       );
-    case 3: // Priority
+    case ColumnIndex.PRIORITY: // Priority
       return (
         (a.application.review?.workPriority ?? -1) -
         (b.application.review?.workPriority ?? -1)
       );
-    case 4: // Confidence
+    case ColumnIndex.CONFIDENCE: // Confidence
       return (a.confidence ?? -1) - (b.confidence ?? -1);
-    case 5: // Effort
+    case ColumnIndex.EFFORT: // Effort
       const aEffortSortFactor = a.application.review
         ? EFFORT_ESTIMATE_LIST[a.application.review.effortEstimate]
-            ?.sortFactor ?? 0
+            ?.sortFactor || 0
         : 0;
       const bEffortSortFactor = b.application.review
         ? EFFORT_ESTIMATE_LIST[b.application.review.effortEstimate]
-            ?.sortFactor ?? 0
+            ?.sortFactor || 0
         : 0;
       return aEffortSortFactor - bEffortSortFactor;
     default:

--- a/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
+++ b/src/pages/reports/components/adoption-candidate-table/adoption-candidate-table.tsx
@@ -41,24 +41,24 @@ const compareToByColumn = (
       return a.application.name.localeCompare(b.application.name);
     case 2: // Criticality
       return (
-        (a.application.review?.businessCriticality || -1) -
-        (b.application.review?.businessCriticality || -1)
+        (a.application.review?.businessCriticality ?? -1) -
+        (b.application.review?.businessCriticality ?? -1)
       );
     case 3: // Priority
       return (
-        (a.application.review?.workPriority || -1) -
-        (b.application.review?.workPriority || -1)
+        (a.application.review?.workPriority ?? -1) -
+        (b.application.review?.workPriority ?? -1)
       );
     case 4: // Confidence
-      return (a.confidence || -1) - (b.confidence || -1);
+      return (a.confidence ?? -1) - (b.confidence ?? -1);
     case 5: // Effort
       const aEffortSortFactor = a.application.review
         ? EFFORT_ESTIMATE_LIST[a.application.review.effortEstimate]
-            ?.sortFactor || 0
+            ?.sortFactor ?? 0
         : 0;
       const bEffortSortFactor = b.application.review
         ? EFFORT_ESTIMATE_LIST[b.application.review.effortEstimate]
-            ?.sortFactor || 0
+            ?.sortFactor ?? 0
         : 0;
       return aEffortSortFactor - bEffortSortFactor;
     default:

--- a/src/pages/reports/components/adoption-candidate-table/tests/adoption-candidate-table.test.tsx
+++ b/src/pages/reports/components/adoption-candidate-table/tests/adoption-candidate-table.test.tsx
@@ -1,0 +1,108 @@
+import { Review } from "api/models";
+import {
+  TableRowData,
+  ColumnIndex,
+  compareToByColumn,
+} from "../adoption-candidate-table";
+
+describe("AdoptionCandidateTable", () => {
+  const genericReview: Review = {
+    businessCriticality: 999,
+    workPriority: 999,
+    effortEstimate: "small",
+    proposedAction: "refactor",
+  };
+
+  it("Sort by criticality: criticality=zero is greater than review=undefined", () => {
+    // Given
+    const rows: TableRowData[] = [
+      {
+        application: {
+          name: "app0",
+          review: { ...genericReview, businessCriticality: 0 },
+        },
+      },
+      {
+        application: {
+          name: "app1",
+          review: { ...genericReview, businessCriticality: 1 },
+        },
+      },
+      {
+        application: {
+          name: "app2",
+          review: { ...genericReview, businessCriticality: 2 },
+        },
+      },
+      { application: { name: "appUndefined1", review: undefined } },
+      { application: { name: "appUndefined2", review: undefined } },
+    ];
+
+    // When
+    rows.sort((a, b) => compareToByColumn(a, b, ColumnIndex.CRITICALITY));
+
+    // Then
+    expect(rows[0].application.name).toBe("appUndefined1");
+    expect(rows[1].application.name).toBe("appUndefined2");
+    expect(rows[2].application.name).toBe("app0");
+    expect(rows[3].application.name).toBe("app1");
+    expect(rows[4].application.name).toBe("app2");
+  });
+
+  it("Sort by priority: priority=zero is greater than review=undefined", () => {
+    // Given
+    const rows: TableRowData[] = [
+      {
+        application: {
+          name: "app0",
+          review: { ...genericReview, workPriority: 0 },
+        },
+      },
+      {
+        application: {
+          name: "app1",
+          review: { ...genericReview, workPriority: 1 },
+        },
+      },
+      {
+        application: {
+          name: "app2",
+          review: { ...genericReview, workPriority: 2 },
+        },
+      },
+      { application: { name: "appUndefined1", review: undefined } },
+      { application: { name: "appUndefined2", review: undefined } },
+    ];
+
+    // When
+    rows.sort((a, b) => compareToByColumn(a, b, ColumnIndex.PRIORITY));
+
+    // Then
+    expect(rows[0].application.name).toBe("appUndefined1");
+    expect(rows[1].application.name).toBe("appUndefined2");
+    expect(rows[2].application.name).toBe("app0");
+    expect(rows[3].application.name).toBe("app1");
+    expect(rows[4].application.name).toBe("app2");
+  });
+
+  it("Sort by confidence: confidence=zero is greater than confidence=undefined", () => {
+    // Given
+    const rows: TableRowData[] = [
+      { application: { name: "app0" }, confidence: 0 },
+      { application: { name: "app1" }, confidence: 1 },
+      { application: { name: "app2" }, confidence: 2 },
+      { application: { name: "appUndefined1" }, confidence: undefined },
+      { application: { name: "appUndefined2" }, confidence: undefined },
+    ];
+
+    // When
+    rows.sort((a, b) => compareToByColumn(a, b, ColumnIndex.CONFIDENCE));
+
+    // Then
+    expect(rows[0].application.name).toBe("appUndefined1");
+    expect(rows[1].application.name).toBe("appUndefined2");
+    expect(rows[2].application.name).toBe("app0");
+    expect(rows[3].application.name).toBe("app1");
+    expect(rows[4].application.name).toBe("app2");
+  });
+});


### PR DESCRIPTION
Resolves: https://github.com/konveyor/tackle-ui/issues/235

As mentioned in the issue https://github.com/konveyor/tackle-ui/issues/235 the bug only happens with CONFIDENCE=0. The CONFIDENCE value is not inserted by the user directly but is the result of the set of answers given to the questionnaire, so in order to see this working you need to have an application whose CONFIDENCE=0