### PR TITLE
Add suspense for lazy loading

### DIFF
--- a/src/layout/DefaultLayout/DefaultLayout.tsx
+++ b/src/layout/DefaultLayout/DefaultLayout.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Page, SkipToContent } from "@patternfly/react-core";
+import { AppPlaceholder } from "shared/components";
 import { HeaderApp } from "../HeaderApp";
 import { SidebarApp } from "../SidebarApp";
 
@@ -12,7 +13,7 @@ export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children }) => {
   );
 
   return (
-    <React.Fragment>
+    <React.Suspense fallback={<AppPlaceholder />}>
       <Page
         header={<HeaderApp />}
         sidebar={<SidebarApp />}
@@ -22,6 +23,6 @@ export const DefaultLayout: React.FC<DefaultLayoutProps> = ({ children }) => {
       >
         {children}
       </Page>
-    </React.Fragment>
+    </React.Suspense>
   );
 };

--- a/src/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
+++ b/src/layout/DefaultLayout/tests/__snapshots__/DefaultLayout.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Test snapshot 1`] = `
-<Fragment>
+<Suspense
+  fallback={<AppPlaceholder />}
+>
   <Page
     defaultManagedSidebarIsOpen={true}
     header={<HeaderApp />}
@@ -22,5 +24,5 @@ exports[`Test snapshot 1`] = `
       </SkipToContent>
     }
   />
-</Fragment>
+</Suspense>
 `;


### PR DESCRIPTION
Resolves: https://github.com/konveyor/tackle-ui/issues/238

This PR adds `React.Suspense` tag to the layout of the page for doing lazy load. This solves the problem reported in the issue.