### PR TITLE
Change tag and tagtype dropdown's aria-label

### DIFF
--- a/cypress/integration/models/tag-type.ts
+++ b/cypress/integration/models/tag-type.ts
@@ -38,7 +38,9 @@ export class TagTypePage {
     cy.get("input[name='rank']").clear().type(`${formValue.rank}`);
 
     if (formValue.color) {
-      cy.get("button[aria-label='color'].pf-c-select__toggle-button").click();
+      cy.get(
+        "button[aria-label='Options menu'].pf-c-select__toggle-button"
+      ).click();
       cy.get("ul[aria-label='color'].pf-c-select__menu > li > button")
         .contains(formValue.color)
         .click();
@@ -50,7 +52,7 @@ export class TagTypePage {
 
     if (formValue.tagType) {
       cy.get(
-        "button[aria-label='tag-type'].pf-c-select__toggle-button"
+        "button[aria-label='Options menu'].pf-c-select__toggle-button"
       ).click();
       cy.get("ul[aria-label='tag-type'].pf-c-select__menu > li > button")
         .contains(formValue.tagType)

--- a/src/pages/controls/tags/components/tag-form/tag-form.tsx
+++ b/src/pages/controls/tags/components/tag-form/tag-form.tsx
@@ -163,7 +163,7 @@ export const TagForm: React.FC<TagFormProps> = ({ tag, onSaved, onCancel }) => {
               "aria-label": "tag-type",
               "aria-describedby": "tag-type",
               typeAheadAriaLabel: "tag-type",
-              toggleAriaLabel: "tag-type",
+              toggleAriaLabel: "Options menu",
               clearSelectionsAriaLabel: "tag-type",
               removeSelectionAriaLabel: "tag-type",
               placeholderText: t("composed.selectOne", {

--- a/src/pages/controls/tags/components/tag-type-form/tag-type-form.tsx
+++ b/src/pages/controls/tags/components/tag-type-form/tag-type-form.tsx
@@ -182,7 +182,7 @@ export const TagTypeForm: React.FC<TagTypeFormProps> = ({
               "aria-label": "color",
               "aria-describedby": "color",
               typeAheadAriaLabel: "color",
-              toggleAriaLabel: "color",
+              toggleAriaLabel: "Options menu",
               clearSelectionsAriaLabel: "color",
               removeSelectionAriaLabel: "color",
               placeholderText: t("composed.selectOne", {


### PR DESCRIPTION
The https://github.com/konveyor/tackle-ui-tests repository relies on selecting the dropdown of tag and tag-types using `button[aria-label='Options menu']` so this PR will change the aria-label values. This doesn't affect in any way the current behavior of the UI since the `aria-label` is just an attribute within the HTML DOM definition.